### PR TITLE
Gracefully handle websocket CloseNormalClosure

### DIFF
--- a/wsproxy/websocket_proxy.go
+++ b/wsproxy/websocket_proxy.go
@@ -108,6 +108,11 @@ func websocketProxy(w http.ResponseWriter, r *http.Request, h http.Handler) {
 			log.Debugln("[read] reading from socket.")
 			_, p, err := conn.ReadMessage()
 			if err != nil {
+				if cErr, ok := err.(*websocket.CloseError); ok && cErr.Code == websocket.CloseNormalClosure {
+					log.Debugln("[read] websocket closed successfully")
+					return
+				}
+
 				log.Warnln("error reading websocket message:", err)
 				return
 			}


### PR DESCRIPTION
These used to trigger a nasty warning message, now they just log to the debug logger instead.