### PR TITLE
enable transparent cookie forwarding

### DIFF
--- a/wsproxy/websocket_proxy.go
+++ b/wsproxy/websocket_proxy.go
@@ -91,6 +91,8 @@ var defaultHeadersToForward = map[string]bool{
 	"origin":  true,
 	"Referer": true,
 	"referer": true,
+	"Cookie": true,
+	"cookie": true,
 }
 
 func defaultHeaderForwarder(header string) bool {


### PR DESCRIPTION
My implementation replies on using a cookies to authenticate websocket
connections and normal HTTP RESTful endpoints with a mux used to convert
the cookies to metadata.

I believe that this is suitable configuration for the
grpc-websocket-proxy project as it makes the websocket-based requests
more consistent with the standard HTTP based requests (which have
cookies available) at the GRPC gateway.

It also allows the use case of creating a cookie based mechanism to
inject metadata; I simply added an interceptor to convert a specific
cookie into GRPC metadata.

I don't think it introduces a security risk, as handling cookies is
deferred to the GRPC gateway code itself.

Thanks for the websocket gateway, it's made developing a web app that
consumes my GRPC API much easier.