### PR TITLE
Added context to proxy request, fix when websocket close gRPC connect…

### DIFF
--- a/wsproxy/websocket_proxy.go
+++ b/wsproxy/websocket_proxy.go
@@ -164,6 +164,8 @@ func (p *Proxy) proxy(w http.ResponseWriter, r *http.Request) {
 		p.logger.Warnln("error preparing request:", err)
 		return
 	}
+	request = request.WithContext(ctx)
+
 	if swsp := r.Header.Get("Sec-WebSocket-Protocol"); swsp != "" {
 		request.Header.Set("Authorization", transformSubProtocolHeader(swsp))
 	}


### PR DESCRIPTION
I'm using server side stream, when client ws closed python server side call context.is_active() is always True, the proxy is not correctly released.