### PR TITLE
Allow usage of the ping and pong handling of Gorilla websocket.

### DIFF
--- a/wsproxy/websocket_proxy.go
+++ b/wsproxy/websocket_proxy.go
@@ -271,6 +271,9 @@ func (p *Proxy) proxy(w http.ResponseWriter, r *http.Request) {
 			}()
 			for {
 				select {
+				case <-ctx.Done():
+					p.logger.Debugln("ping loop done")
+					return
 				case <-ticker.C:
 					conn.SetWriteDeadline(time.Now().Add(p.pingWait))
 					if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {


### PR DESCRIPTION
With `func WithPingControl(interval time.Duration) Option {}` it is now possible to specify a ping interval. based on this parameter the ping and pong deadlines are calculated. This allows faster detection of mobile clients with connection lost.