### PR TITLE
Fix cancelling request when websocket request is cancelled.

### DIFF
--- a/wsproxy/websocket_proxy.go
+++ b/wsproxy/websocket_proxy.go
@@ -169,7 +169,7 @@ func (p *Proxy) proxy(w http.ResponseWriter, r *http.Request) {
 	defer cancelFn()
 
 	requestBodyR, requestBodyW := io.Pipe()
-	request, err := http.NewRequest(r.Method, r.URL.String(), requestBodyR)
+	request, err := http.NewRequestWithContext(r.Context(), r.Method, r.URL.String(), requestBodyR)
 	if err != nil {
 		p.logger.Warnln("error preparing request:", err)
 		return


### PR DESCRIPTION
I believe this fixes #22.

I believe the WebSocket `r.Context()` should be passed to the newly created request object. When the WebSocket client disconnects, `r.Context().Done()` is fired. Without passing this context to the newly created request, the wrapped handler is not aware when a disconnect happens (see #22).