### PR TITLE
Monkey-patch for Golang bufio.Scanner hardcoded maxTokenSize = 64 KB

### DIFF
--- a/wsproxy/websocket_proxy.go
+++ b/wsproxy/websocket_proxy.go
@@ -2,6 +2,8 @@ package wsproxy
 
 import (
 	"bufio"
+	"reflect"
+	"unsafe"
 	"fmt"
 	"io"
 	"net/http"
@@ -285,6 +287,13 @@ func (p *Proxy) proxy(w http.ResponseWriter, r *http.Request) {
 	}
 	// write loop -- take messages from response and write to websocket
 	scanner := bufio.NewScanner(responseBodyR)
+	// Golang bufio.Scanner has hardcoded maxTokenSize = 64 KB
+	pointerVal := reflect.ValueOf(scanner)
+	val := reflect.Indirect(pointerVal)
+	member := val.FieldByName("maxTokenSize")
+	ptrToField := unsafe.Pointer(member.UnsafeAddr())
+	realPtrToField := (*int)(ptrToField)
+	*realPtrToField = 0x7fffffff
 
 	// if maxRespBodyBufferSize has been specified, use custom buffer for scanner
 	var scannerBuf []byte


### PR DESCRIPTION
Hi! There's a problem that affects etcd: grpc-websocket-proxy doesn't handle server messages (i.e replies!) longer 64 KB.
Problem lies in Golang's bufio.Scanner that has a hard-coded maxTokenSize value equal to 64 KB.
Error message in this case is:
`time="2020-10-18T15:42:56Z" level=warning msg="scanner err: bufio.Scanner: token too long"`
In this pull request I submit a rather ugly fix for this problem. It overwrites a private field inside the bufio.Scanner.
I think it may be viable as a quick fix, but of course I'll appreciate if you'll fix it in some proper way. :-)
A simple test example that reproduces the bug in etcd is here: https://gist.github.com/vitalif/a634ac0543e6cacdda4ec288d922d9cf
