### PR TITLE
fix: set write deadline before writing messages

### DIFF
--- a/wsproxy/websocket_proxy.go
+++ b/wsproxy/websocket_proxy.go
@@ -294,6 +294,9 @@ func (p *Proxy) proxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for scanner.Scan() {
+		if p.pingWait > 0 {
+			conn.SetWriteDeadline(time.Now().Add(p.pingWait))
+		}
 		if len(scanner.Bytes()) == 0 {
 			p.logger.Warnln("[write] empty scan", scanner.Err())
 			continue


### PR DESCRIPTION
I was having some weird behavior here when I set up ping/pong to keep the connection alive, where even with that, I was getting disconnected after some time.

Them I checked gorilla/websocket sample on how to keep the connection alive and noticed that their base samples resets the WriteDeadline on every write, this way keeping the connection alive.
https://github.com/gorilla/websocket/blob/master/examples/chat/client.go#L91

So this commit added that behavior. 