### PR TITLE
Use response headers x-grpc-request-type and x-grpc-gateway-body to etermine when to close the request writer

### DIFF
--- a/wsproxy/websocket_proxy.go
+++ b/wsproxy/websocket_proxy.go
@@ -317,6 +317,13 @@ func (p *Proxy) proxy(w http.ResponseWriter, r *http.Request) {
 			p.logger.Warnln("[write] error writing websocket message:", err)
 			return
 		}
+		if grpcMethodType == "Unary" || grpcMethodType == "ClientStreaming" {
+			// Close WebSocket
+			if err = conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
+				p.logger.Warnln("[write] error writing websocket close message:", err)
+				return
+			}
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		p.logger.Warnln("scanner err:", err)


### PR DESCRIPTION
This is a preliminary PR suggesting a method of detecting which type of method (Unary, ServerStreaming, ClientStreaming, DuplexStreaming) grpc-gateway is serving, and whether or not it expects a body.

---

The grpc-gateway implementation was *very* liberal with the data it accepted.
In case of Unary and ClientStreaming messages:
- it only read the first JSON object if `body` annotation is defined
- it read nothing at all if `body` annotation is not defined

This caused a context leak when clients sent more data than was expected by the gateway.
Then grpc-gateway added a blocking connection drain for Unary method with no `body` annotation defined, which broke grpc-websocket-proxy - since it never closed the `req.Body`, the method never triggered at all.

There is work underway to do implement stricter request checking for Unary and ClientStreaming messages in general, which would break grpc-websocket-proxy as-is.
A possible solution would be to add the following metadata in response headers:
- x-grpc-method-type (oneof: Unary, ServerStreaming, ClientStreaming, DuplexStreaming)
- x-grpc-gateway-body (oneof: true, false)

Then, grpc-websocket-proxy could do the following:
- on Unary and ServerStreaming methods:
  - if body is expected, wait for first message from websocket, then close the request body
  - if body is not expected, close the request body without sending anything
- on Unary and ClientStreaming methods:
  - as soon as response is received, close the websocket

Before this is merged, this PR needs to be merged, and grpc-gateway version updated in go.mod:
- https://github.com/grpc-ecosystem/grpc-gateway/pull/5331